### PR TITLE
Fixups for the Nextloud's built-in updater, added occ alias and script for the root user

### DIFF
--- a/overlay/usr/local/etc/php-fpm.conf
+++ b/overlay/usr/local/etc/php-fpm.conf
@@ -515,7 +515,7 @@ env[PATH] = /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 env[TMP] = /tmp
 env[TMPDIR] = /tmp
 env[TEMP] = /tmp
-php_admin_value[session.save_path] = "/usr/local/www/nextcloud/tmp"
+php_admin_value[session.save_path] = "/usr/local/www/nextcloud-sessions-tmp"
 
 ; Additional php.ini defines, specific to this pool of workers. These settings
 ; overwrite the values previously defined in the php.ini. The directives are the

--- a/overlay/usr/local/etc/php-fpm.d/nextcloud.conf
+++ b/overlay/usr/local/etc/php-fpm.d/nextcloud.conf
@@ -9,4 +9,4 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
-php_admin_value[session.save_path] = "/usr/local/www/nextcloud/tmp" 
+php_admin_value[session.save_path] = "/usr/local/www/nextcloud-sessions-tmp" 


### PR DESCRIPTION
The `tmp` folder in `/usr/local/www/nextcloud` directory and root:wheel as the owner of the nextcloud folder and its files impair the Nextcloud updater.
This patch relocates the `tmp` folder to `/usr/local/www/nextcloud-sessions-tmp` and changes ownership of the files to www:www.
Solves #1.

Also adds an alias occ alias for the root user, enables issuing cli commands simply as `occ help status` etc.