### PR TITLE
Set php.ini opcache settings according to nextcloud documentation

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -6,6 +6,15 @@ sysrc -f /etc/rc.conf mysql_enable="YES"
 sysrc -f /etc/rc.conf php_fpm_enable="YES"
 
 cp /usr/local/etc/php.ini-production /usr/local/etc/php.ini
+# Modify opcache settings in php.ini according to Nextcloud documentation (remove comment and set recommended value)
+# https://docs.nextcloud.com/server/15/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+sed -i '' 's/.*opcache.enable=.*/opcache.enable=1/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.enable_cli=.*/opcache.enable_cli=1/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.interned_strings_buffer=.*/opcache.interned_strings_buffer=8/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.max_accelerated_files=.*/opcache.max_accelerated_files=10000/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.memory_consumption=.*/opcache.memory_consumption=128/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.save_comments=.*/opcache.savegit_comments=1/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.revalidate_freq=.*/opcache.revalidate_freq=1/' /usr/local/etc/php.ini
 
 # Start the service
 service nginx start 2>/dev/null


### PR DESCRIPTION
Nextcloud documentation recommends to enable opcache in php.ini settings.
see https://docs.nextcloud.com/server/15/admin_manual/configuration_server/server_tuning.html#enable-php-opcache

This will avoid disturbing warnings in nextcloud admin page ( see issue #7 )
