### PR TITLE
fix in post_install.sh and increase memory_limit as recommended

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -15,6 +15,8 @@ sed -i '' 's/.*opcache.max_accelerated_files=.*/opcache.max_accelerated_files=10
 sed -i '' 's/.*opcache.memory_consumption=.*/opcache.memory_consumption=128/' /usr/local/etc/php.ini
 sed -i '' 's/.*opcache.save_comments=.*/opcache.save_comments=1/' /usr/local/etc/php.ini
 sed -i '' 's/.*opcache.revalidate_freq=.*/opcache.revalidate_freq=1/' /usr/local/etc/php.ini
+# recommended value of 512MB for php memory limit (avoid warning when running occ)
+sed -i '' 's/.*memory_limit.*/memory_limit=512M/' /usr/local/etc/php.ini
 
 # Start the service
 service nginx start 2>/dev/null

--- a/post_install.sh
+++ b/post_install.sh
@@ -13,7 +13,7 @@ sed -i '' 's/.*opcache.enable_cli=.*/opcache.enable_cli=1/' /usr/local/etc/php.i
 sed -i '' 's/.*opcache.interned_strings_buffer=.*/opcache.interned_strings_buffer=8/' /usr/local/etc/php.ini
 sed -i '' 's/.*opcache.max_accelerated_files=.*/opcache.max_accelerated_files=10000/' /usr/local/etc/php.ini
 sed -i '' 's/.*opcache.memory_consumption=.*/opcache.memory_consumption=128/' /usr/local/etc/php.ini
-sed -i '' 's/.*opcache.save_comments=.*/opcache.savegit_comments=1/' /usr/local/etc/php.ini
+sed -i '' 's/.*opcache.save_comments=.*/opcache.save_comments=1/' /usr/local/etc/php.ini
 sed -i '' 's/.*opcache.revalidate_freq=.*/opcache.revalidate_freq=1/' /usr/local/etc/php.ini
 
 # Start the service


### PR DESCRIPTION
first patch is to fix a type in post_install from my previous patch (strange that it still removes warning when tested)
second patch is to increase memory_limit to 512M instead of 128M. Recommended value of 512M is displayed when running occ.

Fix for issue #9 
![2019-01-22_20-20-56](https://user-images.githubusercontent.com/12612524/51568426-fe7dd600-1e99-11e9-8808-d6ac0eb9e63e.png)
