### PR TITLE
Changing defaut value of pm.max_children to 10

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -17,6 +17,8 @@ sed -i '' 's/.*opcache.save_comments=.*/opcache.save_comments=1/' /usr/local/etc
 sed -i '' 's/.*opcache.revalidate_freq=.*/opcache.revalidate_freq=1/' /usr/local/etc/php.ini
 # recommended value of 512MB for php memory limit (avoid warning when running occ)
 sed -i '' 's/.*memory_limit.*/memory_limit=512M/' /usr/local/etc/php.ini
+# recommended value of 10 (instead of 5) to avoid timeout
+sed -i '' 's/.*pm.max_children.*/pm.max_children=10/' /usr/local/etc/php-fpm.d/nextcloud.conf
 
 # Start the service
 service nginx start 2>/dev/null


### PR DESCRIPTION
Changing defaut value of pm.max_children to 10 (instead of 5) as it generate 504 errors on a fresh install