### PR TITLE
Complete Nextcloud installation

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -43,8 +43,6 @@ NCPASS=`cat /root/ncpassword`
 
 echo "Nextcloud Admin User: $NCUSER"
 echo "Nextcloud Admin Password: $NCPASS"
-echo "Database User: $USER"
-echo "Database Password: $PASS"
 
 # Configure mysql
 mysql -u root <<-EOF

--- a/post_install.sh
+++ b/post_install.sh
@@ -28,14 +28,20 @@ service mysql-server start 2>/dev/null
 #https://docs.nextcloud.com/server/13/admin_manual/installation/installation_wizard.html do not use the same name for user and db
 USER="dbadmin"
 DB="nextcloud"
+NCUSER="ncadmin"
 
 # Save the config values
 echo "$DB" > /root/dbname
 echo "$USER" > /root/dbuser
+echo "$NCUSER" > /root/ncuser
 export LC_ALL=C
 cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1 > /root/dbpassword
+cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1 > /root/ncpassword
 PASS=`cat /root/dbpassword`
+NCPASS=`cat /root/ncpassword`
 
+echo "Nextcloud Admin User: $NCUSER"
+echo "Nextcloud Admin Password: $NCPASS"
 echo "Database User: $USER"
 echo "Database Password: $PASS"
 
@@ -51,6 +57,9 @@ GRANT ALL PRIVILEGES ON *.* TO '${USER}'@'localhost' WITH GRANT OPTION;
 GRANT ALL PRIVILEGES ON ${DB}.* TO '${USER}'@'localhost';
 FLUSH PRIVILEGES;
 EOF
+
+#Use occ to complete Nextcloud installation
+su -m www -c "php /usr/local/www/nextcloud/occ maintenance:install --database=\"mysql\" --database-name=\"nextcloud\" --database-user=\"$USER\" --database-pass=\"$PASS\" --database-host=\"localhost\" --admin-user=\"$NCUSER\" --admin-pass=\"$NCPASS\" --data-dir=\"/usr/local/www/nextcloud/data\"" 
 
 #workaround for occ (in shell just use occ instead of su -m www -c "....")
 echo >> .cshrc

--- a/post_install.sh
+++ b/post_install.sh
@@ -29,7 +29,6 @@ service mysql-server start 2>/dev/null
 USER="dbadmin"
 DB="nextcloud"
 NCUSER="ncadmin"
-JAIL_IP=$(ifconfig | grep inet | cut -d ' ' -f 2)
 
 # Save the config values
 echo "$DB" > /root/dbname
@@ -59,7 +58,7 @@ EOF
 
 #Use occ to complete Nextcloud installation
 su -m www -c "php /usr/local/www/nextcloud/occ maintenance:install --database=\"mysql\" --database-name=\"nextcloud\" --database-user=\"$USER\" --database-pass=\"$PASS\" --database-host=\"localhost\" --admin-user=\"$NCUSER\" --admin-pass=\"$NCPASS\" --data-dir=\"/usr/local/www/nextcloud/data\"" 
-su -m www -c "php /usr/local/www/nextcloud/occ config:system:set trusted_domains 1 --value=\"${JAIL_IP}\""
+su -m www -c "php /usr/local/www/nextcloud/occ config:system:set trusted_domains 1 --value=\"${IOCAGE_PLUGIN_IP}\""
 
 #workaround for occ (in shell just use occ instead of su -m www -c "....")
 echo >> .cshrc

--- a/post_install.sh
+++ b/post_install.sh
@@ -29,6 +29,7 @@ service mysql-server start 2>/dev/null
 USER="dbadmin"
 DB="nextcloud"
 NCUSER="ncadmin"
+JAIL_IP=$(ifconfig | grep inet | cut -d ' ' -f 2)
 
 # Save the config values
 echo "$DB" > /root/dbname
@@ -60,6 +61,7 @@ EOF
 
 #Use occ to complete Nextcloud installation
 su -m www -c "php /usr/local/www/nextcloud/occ maintenance:install --database=\"mysql\" --database-name=\"nextcloud\" --database-user=\"$USER\" --database-pass=\"$PASS\" --database-host=\"localhost\" --admin-user=\"$NCUSER\" --admin-pass=\"$NCPASS\" --data-dir=\"/usr/local/www/nextcloud/data\"" 
+su -m www -c "php /usr/local/www/nextcloud/occ config:system:set trusted_domains 1 --value=\"${JAIL_IP}\""
 
 #workaround for occ (in shell just use occ instead of su -m www -c "....")
 echo >> .cshrc

--- a/settings.json
+++ b/settings.json
@@ -21,5 +21,17 @@
 			"description": "Password to use for NextCloud Database setup",
 			"readonly": true
 		}
+		"ncuser": {
+			"type": "string",
+			"name": "Nextcloud Username",
+			"description": "Username of Nextcloud administrator",
+			"readonly": true
+		}
+		"ncpassword": {
+			"type": "string",
+			"name": "Nextcloud Admin Password",
+			"description": "Default Nextcloud administrator password",
+			"readonly": true
+		}
 	}
 }


### PR DESCRIPTION
This commit creates a Nextcloud admin user (`ncadmin`) with a random password, and uses the `occ` command to complete the Nextcloud installation.  On installation of the plugin, the user is now presented with a ready-to-use Nextcloud installation.