### PR TITLE
Update NGINX config per Nextcloud 19 docs.

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf
+++ b/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf
@@ -77,7 +77,7 @@ server {
     deny all;
   }
 
-  location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
+  location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
     fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
     set $path_info $fastcgi_path_info;
     try_files $fastcgi_script_name =404;
@@ -128,7 +128,7 @@ server {
     access_log off;
   }
 
-  location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap)$ {
+  location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$ {
     try_files $uri /index.php$request_uri;
     # Optional: Don't log access to other assets
     access_log off;


### PR DESCRIPTION
The recommended NGINX configuration in the [Nextcloud 18 and 19
documentation](https://docs.nextcloud.com/server/19/admin_manual/installation/nginx.html) adds handling for richdocuments, MP4, and WebM files.
Update the Nextcloud NGINX configuration accordingly.