### PR TITLE
Set PATH environment for nextcloud

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -36,13 +36,8 @@ sed -i '' 's/.*opcache.revalidate_freq=.*/opcache.revalidate_freq=1/' /usr/local
 sed -i '' 's/.*memory_limit.*/memory_limit=512M/' /usr/local/etc/php.ini
 # recommended value of 10 (instead of 5) to avoid timeout
 sed -i '' 's/.*pm.max_children.*/pm.max_children=10/' /usr/local/etc/php-fpm.d/nextcloud.conf
-# Nextcloud wants PATH environment variable set.  Use the same
-# environment variables found in the 'www' php-fpm configuration for
-# Nextcloud.
-if [ -e /usr/local/etc/php-fpm.d/www.conf ] ; then
-    cat /usr/local/etc/php-fpm.d/www.conf |
-        grep "^env\[" >> /usr/local/etc/php-fpm.d/nextcloud.conf
-fi
+# Nextcloud wants PATH environment variable set. 
+echo "env[PATH] = $PATH" >> /usr/local/etc/php-fpm.d/nextcloud.conf
 
 # Start the service
 service nginx start 2>/dev/null


### PR DESCRIPTION
Fix #23 

The other environment variables noted in the nexcloud documentation https://docs.nextcloud.com/server/19/admin_manual/installation/source_installation.html#php-fpm-configuration-notes are not set inside the cage so I dont forward it here. If next cloud would need it, it would complain about it 😉 

This PR has been tested locally and is ready for review.