### PR TITLE
Update Nextcloud NGINX configuration.

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf.template
+++ b/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf.template
@@ -1,136 +1,136 @@
 upstream php-handler {
-  server unix:/var/run/nextcloud-php-fpm.sock;
+    server unix:/var/run/nextcloud-php-fpm.sock;
 }
 
 server {
-  listen 80;
-  server_name _;
+    listen 80;
+    server_name _;
 
-  # Add headers to serve security related headers
-  # Before enabling Strict-Transport-Security headers please read into this
-  # topic first.
-  add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-  #
-  # WARNING: Only add the preload option once you read about
-  # the consequences in https://hstspreload.org/. This option
-  # will add the domain to a hardcoded list that is shipped
-  # in all major browsers and getting removed from this list
-  # could take several months.
-  add_header Referrer-Policy "no-referrer" always;
-  add_header X-Content-Type-Options "nosniff" always;
-  add_header X-Download-Options "noopen" always;
-  add_header X-Frame-Options "SAMEORIGIN" always;
-  add_header X-Permitted-Cross-Domain-Policies "none" always;
-  add_header X-Robots-Tag "none" always;
-  add_header X-XSS-Protection "1; mode=block" always;
-
-  # Remove X-Powered-By, which is an information leak
-  fastcgi_hide_header X-Powered-By;
-
-  # Path to the root of your installation
-  root /usr/local/www/nextcloud/;
-
-  location = /robots.txt {
-    allow all;
-    log_not_found off;
-    access_log off;
-  }
-
-  # The following 2 rules are only needed for the user_webfinger app.
-  rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-  rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-  # The following rule is only needed for the Social app.
-  rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-  location = /.well-known/carddav {
-    return 301 $scheme://$host:$server_port/remote.php/dav;
-  }
-  location = /.well-known/caldav {
-    return 301 $scheme://$host:$server_port/remote.php/dav;
-  }
-
-  # set max upload size
-  client_max_body_size 10G;
-  fastcgi_buffers 64 4K;
-
-  # Enable gzip but do not remove ETag headers
-  gzip on;
-  gzip_vary on;
-  gzip_comp_level 4;
-  gzip_min_length 256;
-  gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-  gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
-
-  # Uncomment if your server was built with the ngx_pagespeed module
-  # This module is currently not supported.
-  #pagespeed off;
-
-  location / {
-    rewrite ^ /index.php;
-  }
-
-  location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
-    deny all;
-  }
-  location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
-    deny all;
-  }
-
-  location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
-    fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
-    set $path_info $fastcgi_path_info;
-    try_files $fastcgi_script_name =404;
-    include fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_param PATH_INFO $path_info;
-    #This would not work yet because we dont create ssl
-    #fastcgi_param HTTPS on;
-    # Avoid sending the security headers twice
-    fastcgi_param modHeadersAvailable true;
-    # Enable pretty urls
-    fastcgi_param front_controller_active true;
-    fastcgi_pass php-handler;
-    fastcgi_intercept_errors on;
-    fastcgi_request_buffering off;
-  }
-
-  location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {
-    try_files $uri/ =404;
-    index index.php;
-  }
-
-  # Adding the cache control header for js, css and map files
-  # Make sure it is BELOW the PHP block
-  location ~ \.(?:css|js|woff2?|svg|gif|map)$ {
-    try_files $uri /index.php$request_uri;
-    add_header Cache-Control "public, max-age=15778463";
-    # Add headers to serve security related headers (It is intended to
-    # have those duplicated to the ones above)
-    # Before enabling Strict-Transport-Security headers please read into
-    # this topic first.
-    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
-    #
+    # HSTS settings
     # WARNING: Only add the preload option once you read about
     # the consequences in https://hstspreload.org/. This option
     # will add the domain to a hardcoded list that is shipped
     # in all major browsers and getting removed from this list
     # could take several months.
-    add_header Referrer-Policy "no-referrer" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Download-Options "noopen" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Permitted-Cross-Domain-Policies "none" always;
-    add_header X-Robots-Tag "none" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
 
-    # Optional: Don't log access to assets
-    access_log off;
-  }
+    # set max upload size
+    client_max_body_size 10G;
+    fastcgi_buffers 64 4K;
 
-  location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$ {
-    try_files $uri /index.php$request_uri;
-    # Optional: Don't log access to other assets
-    access_log off;
-  }
+    # Enable gzip but do not remove ETag headers
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 4;
+    gzip_min_length 256;
+    gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+
+    # Pagespeed is not supported by Nextcloud, so if your server is built
+    # with the `ngx_pagespeed` module, uncomment this line to disable it.
+    #pagespeed off;
+
+    # HTTP response headers borrowed from Nextcloud `.htaccess`
+    add_header Referrer-Policy                      "no-referrer"   always;
+    add_header X-Content-Type-Options               "nosniff"       always;
+    add_header X-Download-Options                   "noopen"        always;
+    add_header X-Frame-Options                      "SAMEORIGIN"    always;
+    add_header X-Permitted-Cross-Domain-Policies    "none"          always;
+    add_header X-Robots-Tag                         "none"          always;
+    add_header X-XSS-Protection                     "1; mode=block" always;
+
+    # Remove X-Powered-By, which is an information leak
+    fastcgi_hide_header X-Powered-By;
+
+    # Path to the root of your installation
+    root /usr/local/www/nextcloud/;
+
+    # Specify how to handle directories -- specifying `/index.php$request_uri`
+    # here as the fallback means that Nginx always exhibits the desired behaviour
+    # when a client requests a path that corresponds to a directory that exists
+    # on the server. In particular, if that directory contains an index.php file,
+    # that file is correctly served; if it doesn't, then the request is passed to
+    # the front-end controller. This consistent behaviour means that we don't need
+    # to specify custom rules for certain paths (e.g. images and other assets,
+    # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+    # `try_files $uri $uri/ /index.php$request_uri`
+    # always provides the desired behaviour.
+    index index.php index.html /index.php$request_uri;
+
+    # Default Cache-Control policy
+    expires 1m;
+
+    # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
+    location = / {
+        if ( $http_user_agent ~ ^DavClnt ) {
+            return 302 /remote.php/webdav/$is_args$args;
+        }
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    # Make a regex exception for `/.well-known` so that clients can still
+    # access it despite the existence of the regex rule
+    # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+    # for `/.well-known`.
+    location ^~ /.well-known {
+        # The following 6 rules are borrowed from `.htaccess`
+
+        rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
+        rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
+        rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
+        rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
+
+        location = /.well-known/carddav     { return 301 /remote.php/dav/; }
+        location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+
+        try_files $uri $uri/ =404;
+    }
+
+    # Rules borrowed from `.htaccess` to hide certain paths from clients
+    location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
+    location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)              { return 404; }
+
+    # Ensure this block, which passes PHP files to the PHP process, is above the blocks
+    # which handle static assets (as seen below). If this block is not declared first,
+    # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
+    # to the URI, resulting in a HTTP 500 error response.
+    location ~ \.php(?:$|/) {
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        set $path_info $fastcgi_path_info;
+
+        try_files $fastcgi_script_name =404;
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $path_info;
+        fastcgi_param HTTPS on;
+
+        fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
+        fastcgi_param front_controller_active true;     # Enable pretty urls
+        fastcgi_pass php-handler;
+
+        fastcgi_intercept_errors on;
+        fastcgi_request_buffering off;
+    }
+
+    location ~ \.(?:css|js|svg|gif)$ {
+        try_files $uri /index.php$request_uri;
+        expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+        access_log off;     # Optional: Don't log access to assets
+    }
+
+    location ~ \.woff2?$ {
+        try_files $uri /index.php$request_uri;
+        expires 7d;         # Cache-Control policy borrowed from `.htaccess`
+        access_log off;     # Optional: Don't log access to assets
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php$request_uri;
+    }
 }


### PR DESCRIPTION
The [recommended NGINX configuration](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html) in the latest Nextcloud
documentation was once again updated.  Update the NGINX Nextcloud
configuration overlay, accordingly.

The update does the following:
  * simplifies rules for well-known locations and asset handling
  * adds a set of default cache control policies (expiry)
  * adds support for Microsoft DAV clients

The updated configuration is a verbatim copy of the recommended
configuration with modifications specific to the FreeNAS Nextcloud
plugin, i.e. no SSL/TLS configuration, a different root path, a larger
maximum file upload size, and enabling of strict transport security.
This is consistent with earlier versions of the Nextcloud plugin
NGINX configuration.
