### PR TITLE
Update nginx config to Nextcloud 21 recommendation

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf.template
+++ b/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf.template
@@ -57,9 +57,6 @@ server {
     # always provides the desired behaviour.
     index index.php index.html /index.php$request_uri;
 
-    # Default Cache-Control policy
-    expires 1m;
-
     # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
     location = / {
         if ( $http_user_agent ~ ^DavClnt ) {
@@ -80,13 +77,10 @@ server {
     location ^~ /.well-known {
         # The following 6 rules are borrowed from `.htaccess`
 
-        rewrite ^/\.well-known/host-meta\.json  /public.php?service=host-meta-json  last;
-        rewrite ^/\.well-known/host-meta        /public.php?service=host-meta       last;
-        rewrite ^/\.well-known/webfinger        /public.php?service=webfinger       last;
-        rewrite ^/\.well-known/nodeinfo         /public.php?service=nodeinfo        last;
-
         location = /.well-known/carddav     { return 301 /remote.php/dav/; }
         location = /.well-known/caldav      { return 301 /remote.php/dav/; }
+        # Anything else is dynamically handled by Nextcloud
+        location ^~ /.well-known            { return 301 /index.php$uri; }
 
         try_files $uri $uri/ =404;
     }


### PR DESCRIPTION
The Nextcloud 21 recommended nginx configuration changes how
`/.well-known` URLs are handled, and also drops the global cache expiry
setting.  Update `nextcloud.conf.template` accordingly.

See the following for details:
https://docs.nextcloud.com/server/21/admin_manual/installation/nginx.html