### PR TITLE
Add generate_letsencrypt_certificates script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,7 @@ Certificate validity time:
 To generate valid certificates with Letsencrypt, first, make sure that TrueNAS is configured to proxy requests using your domain name to Nextcloud and that the Nextcloud jail is accessible through ports 80 and 443. You can then run the following commands to install valid certificates:
 
 ```bash
-# Remove self-signed certificates
-rm -rf /usr/local/etc/letsencrypt/truenas
-
-# Ask letsencrypt for some certificates
-certbot certonly \
-    --rsa-key-size 4096 \
-    --cert-name truenas \
-    --non-interactive \
-    --webroot \
-    --webroot-path /usr/local/www/nextcloud \
-    --force-renewal \
-    --agree-tos \
-    --email <your_email> \
-    --domain <your_domain_name>
-
-# Refresh nginx configuration to use 443 as HTTPS port
-sync_configuration
-
-# Restart nginx
-service nginx restart
+generate_letsencrypt_certificates <domain_name> <admin_email>
 ```
 
 Then add your domain to Nextcloud known hosts in: `/usr/local/www/nextcloud/config/config.php`.

--- a/overlay/usr/local/bin/generate_letsencrypt_certificates
+++ b/overlay/usr/local/bin/generate_letsencrypt_certificates
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -eu
+
+. load_env
+
+domain_name=${1:-}
+admin_email=${2:-}
+
+if [ "$domain_name" = "" ]
+then
+	echo "Please provide a domain name: generate_letsencrypt_certificates <domain_name> <admin_email>"
+	exit 1
+fi
+
+if [ "$admin_email" = "" ]
+then
+	echo "Please provide a admin email: generate_letsencrypt_certificates <domain_name> <admin_email>"
+	exit 1
+fi
+
+# Move self-signed certificates
+tmp_backup="/tmp/$(openssl rand --hex 8)"
+mkdir --parent "$tmp_backup"
+mv /usr/local/etc/letsencrypt/live/truenas "$tmp_backup"
+echo "Old certificates moved to: $tmp_backup"
+
+# Ask letsencrypt for some certificates
+certbot certonly \
+    --rsa-key-size 4096 \
+    --cert-name truenas \
+    --non-interactive \
+    --webroot \
+    --webroot-path /usr/local/www/nextcloud \
+    --force-renewal \
+    --agree-tos \
+    --email "$admin_email" \
+    --domain "$domain_name"
+
+# Refresh nginx configuration to use 443 as HTTPS port
+sync_configuration
+
+# Restart nginx
+service nginx restart


### PR DESCRIPTION
Currently, there are only some information on the commands to run listed in the README. It would be easier to have a script to handle that automatically.

Sadly the testing procedure is complicated, so I have not made it. But I did test the code during my plugin review in august so it should be safe.

- Setup your TrueNAS VM and install the Nextcloud Plugin
- Make it accessible from the internet
- Point a domain name to its IP address
- Add the domain to TrueNAS and configure your Nextcloud Plugin to use the domain
- Enter the Nextcloud plugin shell and run:
```shell
generate_letsencrypt_certificates <domain_name> <admin_email>
```