### PR TITLE
12.2 release

### DIFF
--- a/overlay/usr/local/bin/generate_letsencrypt_certificates
+++ b/overlay/usr/local/bin/generate_letsencrypt_certificates
@@ -21,12 +21,7 @@ fi
 
 # Move self-signed certificates
 tmp_backup="/tmp/$(openssl rand --hex 8)"
-mkdir --parent "$tmp_backup"
-if [ $? -eq 64 ]
-        mkdir -p "$tmp_backup"
-else
-        echo "Unable to create certificate backup" >&2
-fi
+mkdir -p "$tmp_backup"
 mv /usr/local/etc/letsencrypt/live/truenas "$tmp_backup"
 echo "Old certificates moved to: $tmp_backup"
 

--- a/overlay/usr/local/bin/generate_letsencrypt_certificates
+++ b/overlay/usr/local/bin/generate_letsencrypt_certificates
@@ -22,6 +22,11 @@ fi
 # Move self-signed certificates
 tmp_backup="/tmp/$(openssl rand --hex 8)"
 mkdir --parent "$tmp_backup"
+if [ $? -eq 64 ]
+        mkdir -p "$tmp_backup"
+else
+        echo "Unable to create certificate backup" >&2
+fi
 mv /usr/local/etc/letsencrypt/live/truenas "$tmp_backup"
 echo "Old certificates moved to: $tmp_backup"
 


### PR DESCRIPTION
`mkdir --parent` is not a valid command and throws an error `usage: illegal option -- -`. This PR changes the command to `mkdir -p` to no longer throw the above error. This will also resolve #46 