### PR TITLE
Add legacy support rewrite statement into nextcloud.conf.template

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf.template
+++ b/overlay/usr/local/etc/nginx/conf.d/nextcloud.conf.template
@@ -94,6 +94,9 @@ server {
     # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
     # to the URI, resulting in a HTTP 500 error response.
     location ~ \.php(?:$|/) {
+        # Required for legacy support
+        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;     
+
         fastcgi_split_path_info ^(.+?\.php)(/.*)$;
         set $path_info $fastcgi_path_info;
 


### PR DESCRIPTION
Add legacy support rewrite statement into nextcloud.conf.template as without it
LDAP/AD configuration does not work out of the box.

This change is straight from the nginx configuration example from nextcloud
documentation:
https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html