### PR TITLE
Add noindex and nofollow to X-Robots-Tag header.

### DIFF
--- a/overlay/usr/local/etc/nginx/conf.d/nextcloud.inc
+++ b/overlay/usr/local/etc/nginx/conf.d/nextcloud.inc
@@ -15,13 +15,13 @@ gzip_types application/atom+xml application/javascript application/json applicat
 #pagespeed off;
 
 # HTTP response headers borrowed from Nextcloud `.htaccess`
-add_header Referrer-Policy                      "no-referrer"   always;
-add_header X-Content-Type-Options               "nosniff"       always;
-add_header X-Download-Options                   "noopen"        always;
-add_header X-Frame-Options                      "SAMEORIGIN"    always;
-add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-add_header X-Robots-Tag                         "none"          always;
-add_header X-XSS-Protection                     "1; mode=block" always;
+add_header Referrer-Policy                      "no-referrer"       always;
+add_header X-Content-Type-Options               "nosniff"           always;
+add_header X-Download-Options                   "noopen"            always;
+add_header X-Frame-Options                      "SAMEORIGIN"        always;
+add_header X-Permitted-Cross-Domain-Policies    "none"              always;
+add_header X-Robots-Tag                         "noindex, nofollow" always;
+add_header X-XSS-Protection                     "1; mode=block"     always;
 
 # Remove X-Powered-By, which is an information leak
 fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
The Nextcloud "Overview" in the Settings page flags a potential security risk due to missing "noindex" and "nofollow" in the X-Robots-Tag HTTP response header.  Add them, accordingly.